### PR TITLE
[SAGE-1007] Using pod UIDs to map pod runtime metadata to plugin data.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM python:3.8
-RUN pip3 install https://github.com/waggle-sensor/pywaggle/archive/refs/tags/0.43.2.zip
+COPY requirements.txt .
+RUN pip3 install --no-cache-dir -r requirements.txt
 COPY . .
 ENTRYPOINT [ "python", "main.py" ]


### PR DESCRIPTION
This service now expects messages to set the AMQP app_id property to the Pod UID. This allows us to bind Pod runtime metadata to plugin data.