### PR TITLE
[SAGE-1100] Dropped all user_id related code and only using pod metadata.

### DIFF
--- a/test.py
+++ b/test.py
@@ -1,7 +1,6 @@
 import unittest
 import wagglemsg
 import pika
-from waggle import message
 from kubernetes.client import V1Pod, V1PodSpec, V1ObjectMeta, V1Container
 from main import AppState, load_message, InvalidMessageError
 


### PR DESCRIPTION
All plugin identity is now handled through looking up the Pod metadata using the Pod UID sent with messages.

This allows us to completely drop attempts to embed identity metadata into the RMQ user ID and will allow us to support future metadata as standard Kubernetes labels.