### PR TITLE
Adding support for system publishers.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,6 +17,6 @@ jobs:
       - name: Install dependencies
         run: pip3 install -r requirements.txt
       - name: Wait until containers are ready
-        run: timeout 60 docker-compose exec -T -- wes-rabbitmq rabbitmqctl await_startup
+        run: timeout 60 docker-compose exec -T -- wes-rabbitmq rabbitmqctl await_startup && sleep 10
       - name: Run tests
         run: make test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,6 +17,6 @@ jobs:
       - name: Install dependencies
         run: pip3 install -r requirements.txt
       - name: Wait until containers are ready
-        run: sleep 10
+        run: timeout 60 docker-compose exec -T -- wes-rabbitmq rabbitmqctl await_startup
       - name: Run tests
         run: make test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,6 +12,6 @@ jobs:
       - name: Start service containers
         run: make svc-up
       - name: Wait until containers are ready
-        run: timeout 60 docker-compose exec -T -- wes-rabbitmq rabbitmqctl await_startup && sleep 10
+        run: sleep 10 && timeout 60 docker-compose exec -T -- wes-rabbitmq rabbitmqctl await_startup && sleep 10
       - name: Run tests
         run: make test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,9 +7,6 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.10]
     steps:
       - uses: actions/checkout@v2
       - name: Start service containers

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,8 +11,6 @@ jobs:
       - uses: actions/checkout@v2
       - name: Start service containers
         run: make svc-up
-      - name: Install dependencies
-        run: pip3 install -r requirements.txt
       - name: Wait until containers are ready
         run: timeout 60 docker-compose exec -T -- wes-rabbitmq rabbitmqctl await_startup && sleep 10
       - name: Run tests

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ jobs:
         python-version: [3.10]
     steps:
       - uses: actions/checkout@v2
-      - name: Build and start containers
+      - name: Start service containers
         run: make svc-up
       - name: Install dependencies
         run: pip3 install -r requirements.txt

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,11 +9,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.10]
     steps:
       - uses: actions/checkout@v2
       - name: Build and start containers
         run: make svc-up
+      - name: Install dependencies
+        run: pip3 install -r requirements.txt
       - name: Wait until containers are ready
         run: sleep 10
       - name: Run tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-alpine
+FROM python:3.10-alpine
 WORKDIR /app
 COPY requirements.txt .
 RUN pip3 install --no-cache-dir -r requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@ all:
 
 .PHONY: test
 test:
-	python3 -m unittest -v test.py
+	docker build -t wes-data-sharing-service .
+	docker run -it --rm --network host --entrypoint=python3 wes-data-sharing-service -m unittest -v test.py
 
 .PHONY: svc-up
 svc-up:

--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,11 @@ all:
 
 .PHONY: test
 test:
-	docker-compose exec -T -- wes-data-sharing-service python3 test.py
+	python3 test.py
 
 .PHONY: svc-up
 svc-up:
-	docker-compose up -d --build
+	docker-compose up -d
 
 .PHONY: svc-down
 svc-down:

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ all:
 
 .PHONY: test
 test:
-	python3 test.py
+	python3 -m unittest -v test.py
 
 .PHONY: svc-up
 svc-up:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ all:
 .PHONY: test
 test:
 	docker build -t wes-data-sharing-service .
-	docker run -it --rm --network host --entrypoint=python3 wes-data-sharing-service -m unittest -v test.py
+	docker run --rm --network host --entrypoint=python3 wes-data-sharing-service -m unittest -v test.py
 
 .PHONY: svc-up
 svc-up:

--- a/configs/rabbitmq/definitions.json
+++ b/configs/rabbitmq/definitions.json
@@ -43,5 +43,59 @@
             "write": ".*",
             "read": ".*"
         }
+    ],
+    "queues": [
+        {
+            "name": "to-validator",
+            "vhost": "/",
+            "durable": true,
+            "auto_delete": false,
+            "arguments": {}
+        },
+        {
+            "name": "to-beehive",
+            "vhost": "/",
+            "durable": true,
+            "auto_delete": false,
+            "arguments": {}
+        }
+    ],
+    "exchanges": [
+        {
+            "name": "to-validator",
+            "vhost": "/",
+            "type": "fanout",
+            "durable": true,
+            "auto_delete": false,
+            "internal": false,
+            "arguments": {}
+        },
+        {
+            "name": "to-beehive",
+            "vhost": "/",
+            "type": "fanout",
+            "durable": true,
+            "auto_delete": false,
+            "internal": false,
+            "arguments": {}
+        }
+    ],
+    "bindings": [
+        {
+            "source": "to-validator",
+            "vhost": "/",
+            "destination": "to-validator",
+            "destination_type": "queue",
+            "routing_key": "",
+            "arguments": {}
+        },
+        {
+            "source": "to-beehive",
+            "vhost": "/",
+            "destination": "to-beehive",
+            "destination_type": "queue",
+            "routing_key": "",
+            "arguments": {}
+        }
     ]
 }

--- a/configs/rabbitmq/definitions.json
+++ b/configs/rabbitmq/definitions.json
@@ -1,0 +1,47 @@
+{
+    "users": [
+        {
+            "name": "admin",
+            "password": "admin",
+            "tags": "administrator"
+        },
+        {
+            "name": "service",
+            "password": "service",
+            "tags": ""
+        },
+        {
+            "name": "plugin",
+            "password": "plugin",
+            "tags": ""
+        }
+    ],
+    "vhosts": [
+        {
+            "name": "/"
+        }
+    ],
+    "permissions": [
+        {
+            "user": "admin",
+            "vhost": "/",
+            "configure": ".*",
+            "write": ".*",
+            "read": ".*"
+        },
+        {
+            "user": "service",
+            "vhost": "/",
+            "configure": ".*",
+            "write": ".*",
+            "read": ".*"
+        },
+        {
+            "user": "plugin",
+            "vhost": "/",
+            "configure": ".*",
+            "write": ".*",
+            "read": ".*"
+        }
+    ]
+}

--- a/configs/rabbitmq/rabbitmq.conf
+++ b/configs/rabbitmq/rabbitmq.conf
@@ -1,0 +1,1 @@
+load_definitions = /etc/rabbitmq/definitions.json

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,19 +1,10 @@
 services:
-  wes-data-sharing-service:
-    build: .
-    environment:
-      - "RABBITMQ_HOST=wes-rabbitmq"
-      - "RABBITMQ_USERNAME=guest"
-      - "RABBITMQ_PASSWORD=guest"
-      - "APP_META_CACHE_HOST=wes-app-meta-cache"
-      - "WAGGLE_NODE_ID=0000000000000001"
-      - "WAGGLE_NODE_VSN=W001"
-    ports:
-      - "127.0.0.1:8080:8080"
   wes-rabbitmq:
     image: rabbitmq:3.8.11-alpine
     ports:
       - "127.0.0.1:5672:5672"
+    volumes:
+      - "./configs/rabbitmq:/etc/rabbitmq:ro"
   wes-app-meta-cache:
     image: redis:7.0.4
     ports:

--- a/main.py
+++ b/main.py
@@ -298,7 +298,7 @@ def main():
     )
     parser.add_argument(
         "--dst-exchange-beehive",
-        default=getenv("DST_QUEUE_BEEHIVE", "to-beehive"),
+        default=getenv("DST_EXCHANGE_BEEHIVE", "to-beehive"),
         help="destination exchange for beehive",
     )
     parser.add_argument(

--- a/main.py
+++ b/main.py
@@ -24,7 +24,7 @@ class InvalidMessageError(Exception):
 
 class AppMetaCache:
 
-    def __init__(self, host="127.0.0.1", port=6379):
+    def __init__(self, host, port):
         self.client = Redis(host=host, port=port)
 
     @lru_cache(maxsize=128)

--- a/test.py
+++ b/test.py
@@ -75,7 +75,7 @@ class TestService(unittest.TestCase):
             upload_publish_name="upload",
 
             # app meta cache config
-            app_meta_cache=AppMetaCache(APP_META_CACHE_HOST),
+            app_meta_cache=AppMetaCache(APP_META_CACHE_HOST, APP_META_CACHE_PORT),
 
             system_meta={
                 "node": "0000000000000001",

--- a/test.py
+++ b/test.py
@@ -132,6 +132,7 @@ class TestService(unittest.TestCase):
         results = []
 
         def on_message_callback(ch, method, properties, body):
+            self.assertEqual(properties.delivery_mode, pika.DeliveryMode.Persistent.value)
             results.append(wagglemsg.load(body))
             if len(results) >= len(messages):
                 ch.stop_consuming()

--- a/test.py
+++ b/test.py
@@ -91,10 +91,7 @@ class TestService(unittest.TestCase):
     def setUp(self):
         self.es = ExitStack()
 
-        # setup new background instance of service for testing
         self.service = get_service()
-        threading.Thread(target=self.service.run, daemon=True).start()
-        self.es.callback(self.service.shutdown)
 
         # setup redis client to manually populate meta cache for testing
         self.redis = self.es.enter_context(Redis(TEST_APP_META_CACHE_HOST))
@@ -117,6 +114,10 @@ class TestService(unittest.TestCase):
         # NOTE(sean) pywaggle uses /run/waggle as WAGGLE_PLUGIN_UPLOAD_PATH default. we hack this for now so we can run these unit tests.
         self.upload_dir = self.es.enter_context(TemporaryDirectory())
         os.environ["WAGGLE_PLUGIN_UPLOAD_PATH"] = str(Path(self.upload_dir).absolute())
+
+        # run new background instance of service for testing
+        threading.Thread(target=self.service.run, daemon=True).start()
+        self.es.callback(self.service.shutdown)
 
     def tearDown(self):
         self.es.close()


### PR DESCRIPTION
This PR prototypes the addition of system apps tied to AMQP user IDs. The service now accepts a list of system users as arguments for this.

Functionally, system apps are considered trusted and do not use the app meta cache to override any tagged meta.