### PR TITLE
SAGE-1577: Update pywagglemsg to include type validation as of 0.4.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 pywaggle==0.54.*
+pywagglemsg==0.4.*
 pika==1.2.*
 redis==4.3.*
 prometheus-client==0.14.*


### PR DESCRIPTION
This PR should help address the case of getting malformed messages where the meta field was missing or null.